### PR TITLE
Improvements to joining an etcd cluster

### DIFF
--- a/embetcd/common.go
+++ b/embetcd/common.go
@@ -78,3 +78,14 @@ func RevokeLease(ctx context.Context, client *Client, lease *cli.LeaseGrantRespo
 		client.Revoke(ctx, lease.ID)
 	}
 }
+
+// StringIsInStringSlice returns true if the given string is in the slice of strings
+func StringIsInStringSlice(s string, strs []string) (resp bool) {
+	for _, i := range strs {
+		if s == i {
+			resp = true
+			break
+		}
+	}
+	return
+}

--- a/embetcd/config.go
+++ b/embetcd/config.go
@@ -2,7 +2,6 @@ package embetcd
 
 import (
 	"context"
-	"crypto/tls"
 	"time"
 
 	cli "github.com/coreos/etcd/clientv3"
@@ -31,7 +30,6 @@ func (c *Config) GetClientFromConfig(ctx context.Context) (*Client, error) {
 	return NewClient(cli.Config{
 		Endpoints:        c.InitialCluster,
 		DialTimeout:      DurationOrDefault(c.DialTimeout, DefaultDialTimeout),
-		TLS:              &tls.Config{InsecureSkipVerify: true}, // insecure for now
 		AutoSyncInterval: DurationOrDefault(c.AutoSyncInterval, DefaultAutoSyncInterval),
 		Context:          ctx, // pass in the context so the temp client closes with a cancelled context
 	})


### PR DESCRIPTION
Under certain circumstances when members are joining an etcd cluster, requests made against etcd may block until the startup timeout.  This means that when etcd requests hang, we aren't actually retrying anything because we're blocking until startup times out.  This means that if we have a seeder and kick of 6 joiners at the same time, only some of the joiners will make it into the cluster before things lock up.

This pr does the following:

- Adds individual timeouts for each request in the startup path.  This means we'll timeout when a request hangs, and retry multiple times until the overall start up timeout is reached.
- When joining a cluster, we now check to see if a member exists in the cluster with our peer url.  If there is a peer with our peer urls, we will just start.  This prevents a the request to add a member from hanging.